### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ Installation
 
 Install with [composer](http://getcomposer.org/download)
 
-``` json
-{
-    "require": {
-        "tzander/test-bundle": "dev-master"
-    }
-}
+```sh
+composer require tzander/test-bundle
 ```
-
-
-


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
